### PR TITLE
check for HAVE_GOOGLE_MAPS in AIRGoogleMapOverlay

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,20 +80,24 @@ post_install do |installer|
 end
 ~~~
 
+## iOS - ReactNative Link
 
-## IMPORTANT!!
+Run `react-native link react-native-maps`. Note that by default this will use
+Apple Maps and that the configuration of Google Maps will be more difficult.
 
-**!!  DO NOT USE  !!** `react-native link`
+Functionality that depends on `Google-Maps-iOS-Utils` has been disabled for this
+configuration via runtime errors due to the fact that this framework is not
+available for download as a pre-compiled binary. An exception will be raised if
+you try to use the following features:
 
-Have ran it already? Read [this](#on-ios).
+- Making markers via KML files
 
 ## If you want to use Google maps
-
 
 Add to `ios/_YOUR_PROJECT_NAME_/AppDelegate.m:
 
 ```objc
-+ @import GoogleMaps; //add this line if you want to use Google Maps
++ #import <GoogleMaps/GoogleMaps.h>
 
 @implementation AppDelegate
 ...
@@ -105,6 +109,25 @@ Add to `ios/_YOUR_PROJECT_NAME_/AppDelegate.m:
 ```
 
 This should be the **first line** of the method.
+
+#### If you are not using CocoaPods
+
+If you installed via `react-native-link`, add the following to your
+`package.json` and replace the `REPLACE_ME_RELATIVE_PATH_TO_GOOGLE_MAPS_INSTALL`
+with the relative path from your project root to the directory in which you
+installed the Google Maps frameworks:
+
+```json
+{
+  "name": "your-app",
+  "scripts": {
+    "postinstall": "./node_modules/react-native-maps/enable-google-maps REPLACE_ME_RELATIVE_PATH_TO_GOOGLE_MAPS_INSTALL"
+  }
+}
+```
+
+Re-run `npm install` or `yarn` to ensure the `postinstall` script is run.
+
 
 ## Notes on running on a real ios device
 
@@ -207,16 +230,6 @@ If you have a blank map issue, ([#118](https://github.com/airbnb/react-native-ma
 ### On iOS:
 
 If google logo/markers/polylines etc are displayed, this is likely an API key issue. Verify your API keys and their restrictions. Ensure the native `provideAPIKey` call is the first line of `didFinishLaunchingWithOptions`.
-
-If you have ran 'react-native link` by mistake:
-
-1. delete node_modules
-2. delete ios/Pods
-3. delete ios/Podfile.lock
-4. open Xcode and delete `AIRMaps.xcodeproj` from Libraries if it exists
-5. in Build Phases -> Link Binary With Libraries delete `libAIRMaps.a` if it exists
-6. delete ios/build folder
-7. start again with the installation steps
 
 If you use Xcode with version less than 9 you may get `use of undeclared identifier 'MKMapTypeMutedStandard'` or `Entry, ":CFBundleIdentifier", Does Not Exist` errors. In this case you have to update your Xcode.
 

--- a/enable-google-maps
+++ b/enable-google-maps
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+GOOGLE_MAPS_INSTALL_LOCATION=$1
+
+if [[ -z "$GOOGLE_MAPS_INSTALL_LOCATION" ]]; then
+  echo "usage: enable-google-maps <google-frameworks-relative-install-dir>"
+  exit 1
+fi
+
+cat > lib/ios/User.xcconfig <<EOF
+FRAMEWORK_SEARCH_PATHS = \$(inherited) \$(SRCROOT)/../../../../$GOOGLE_MAPS_INSTALL_LOCATION
+GCC_PREPROCESSOR_DEFINITIONS = \$(inherited) HAVE_GOOGLE_MAPS=1
+EOF

--- a/lib/ios/AirGoogleMaps/AIRDummyView.h
+++ b/lib/ios/AirGoogleMaps/AIRDummyView.h
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 10/4/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <UIKit/UIKit.h>
 
 
@@ -12,3 +14,5 @@
 @property (nonatomic, weak) UIView *view;
 - (instancetype)initWithView:(UIView*)view;
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRDummyView.m
+++ b/lib/ios/AirGoogleMaps/AIRDummyView.m
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 10/4/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <Foundation/Foundation.h>
 #import "AIRDummyView.h"
 
@@ -17,3 +19,5 @@
   return self;
 }
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGMSMarker.h
+++ b/lib/ios/AirGoogleMaps/AIRGMSMarker.h
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/5/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/UIView+React.h>
 
@@ -21,3 +23,5 @@
 @required
 -(void)didTapMarker;
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGMSMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGMSMarker.m
@@ -5,8 +5,12 @@
 //  Created by Gil Birman on 9/5/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGMSMarker.h"
 
 @implementation AIRGMSMarker
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGMSPolygon.h
+++ b/lib/ios/AirGoogleMaps/AIRGMSPolygon.h
@@ -5,6 +5,8 @@
 //  Created by Gerardo Pacheco 02/05/2017.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/UIView+React.h>
 
@@ -14,3 +16,5 @@
 @property (nonatomic, strong) NSString *identifier;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGMSPolygon.m
+++ b/lib/ios/AirGoogleMaps/AIRGMSPolygon.m
@@ -5,8 +5,12 @@
 //  Created by Gerardo Pacheco 02/05/2017.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGMSPolygon.h"
 
 @implementation AIRGMSPolygon
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGMSPolyline.h
+++ b/lib/ios/AirGoogleMaps/AIRGMSPolyline.h
@@ -5,6 +5,8 @@
 //  Created by Guilherme Pontes 04/05/2017.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/UIView+React.h>
 
@@ -14,3 +16,5 @@
 @property (nonatomic, strong) NSString *identifier;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGMSPolyline.m
+++ b/lib/ios/AirGoogleMaps/AIRGMSPolyline.m
@@ -5,7 +5,11 @@
 //  Created by Guilherme Pontes 04/05/2017.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGMSPolyline.h"
 
 @implementation AIRGMSPolyline
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/1/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
 #import <React/RCTBridge.h>
@@ -65,3 +67,5 @@
 + (GMSCameraPosition*)makeGMSCameraPositionFromMap:(GMSMapView *)map andMKCoordinateRegion:(MKCoordinateRegion)region;
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/1/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMap.h"
 #import "AIRGoogleMapMarker.h"
 #import "AIRGoogleMapMarkerManager.h"
@@ -14,14 +16,26 @@
 #import "AIRGoogleMapUrlTile.h"
 #import "AIRGoogleMapOverlay.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import <Google-Maps-iOS-Utils/GMUKMLParser.h>
-#import <Google-Maps-iOS-Utils/GMUPlacemark.h>
-#import <Google-Maps-iOS-Utils/GMUPoint.h>
-#import <Google-Maps-iOS-Utils/GMUGeometryRenderer.h>
 #import <MapKit/MapKit.h>
 #import <React/UIView+React.h>
 #import <React/RCTBridge.h>
 #import "RCTConvert+AirMap.h"
+
+#ifdef HAVE_GOOGLE_MAPS_UTILS
+#import <Google-Maps-iOS-Utils/GMUKMLParser.h>
+#import <Google-Maps-iOS-Utils/GMUPlacemark.h>
+#import <Google-Maps-iOS-Utils/GMUPoint.h>
+#import <Google-Maps-iOS-Utils/GMUGeometryRenderer.h>
+#define REQUIRES_GOOGLE_MAPS_UTILS(feature) do {} while (0)
+#else
+#define GMUKMLParser void
+#define GMUPlacemark void
+#define REQUIRES_GOOGLE_MAPS_UTILS(feature) do { \
+ [NSException raise:@"ReactNativeMapsDependencyMissing" \
+             format:@"Use of " feature "requires Google-Maps-iOS-Utils, you  must install via CocoaPods to use this feature"]; \
+} while (0)
+#endif
+
 
 id regionAsJSON(MKCoordinateRegion region) {
   return @{
@@ -496,6 +510,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 + (NSString *)GetIconUrl:(GMUPlacemark *) marker parser:(GMUKMLParser *) parser {
+#ifdef HAVE_GOOGLE_MAPS_UTILS
   if (marker.style.styleID != nil) {
     for (GMUStyle *style in parser.styles) {
       if (style.styleID == marker.style.styleID) {
@@ -505,6 +520,9 @@ id regionAsJSON(MKCoordinateRegion region) {
   }
 
   return marker.style.iconUrl;
+#else
+    REQUIRES_GOOGLE_MAPS_UTILS("GetIconUrl:parser:"); return @"";
+#endif
 }
 
 - (NSString *)KmlSrc {
@@ -512,6 +530,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)setKmlSrc:(NSString *)kmlUrl {
+#ifdef HAVE_GOOGLE_MAPS_UTILS
 
   _kmlSrc = kmlUrl;
 
@@ -563,6 +582,11 @@ id regionAsJSON(MKCoordinateRegion region) {
 
   id event = @{@"markers": markers};
   if (self.onKmlReady) self.onKmlReady(event);
+#else
+    REQUIRES_GOOGLE_MAPS_UTILS();
+#endif
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.h
@@ -6,6 +6,8 @@
 //
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <UIKit/UIKit.h>
 #import <React/RCTView.h>
 
@@ -13,3 +15,5 @@
 @property (nonatomic, assign) BOOL tooltip;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.m
@@ -6,6 +6,8 @@
 //
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapCallout.h"
 #import <React/RCTUtils.h>
 #import <React/RCTView.h>
@@ -13,3 +15,5 @@
 
 @implementation AIRGoogleMapCallout
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.h
@@ -5,8 +5,13 @@
 //  Created by Gil Birman on 9/6/16.
 //
 //
+
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapCalloutManager : RCTViewManager
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.m
@@ -6,6 +6,8 @@
 //
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapCalloutManager.h"
 #import "AIRGoogleMapCallout.h"
 #import <React/RCTView.h>
@@ -23,3 +25,5 @@ RCT_EXPORT_VIEW_PROPERTY(tooltip, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircle.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircle.h
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/24/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <GoogleMaps/GoogleMaps.h>
 #import "AIRMapCoordinate.h"
 
@@ -18,3 +20,5 @@
 @property (nonatomic, assign) int zIndex;
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircle.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircle.m
@@ -3,6 +3,8 @@
 //
 //  Created by Nick Italiano on 10/24/16.
 //
+
+#ifdef HAVE_GOOGLE_MAPS
 #import <UIKit/UIKit.h>
 #import "AIRGoogleMapCircle.h"
 #import <GoogleMaps/GoogleMaps.h>
@@ -55,3 +57,5 @@
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.h
@@ -4,8 +4,12 @@
 //  Created by Nick Italiano on 10/24/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapCircleManager : RCTViewManager
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.m
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/24/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapCircleManager.h"
 #import "AIRGoogleMapCircle.h"
 #import <React/RCTBridge.h>
@@ -31,3 +33,5 @@ RCT_EXPORT_VIEW_PROPERTY(fillColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(zIndex, int)
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -5,8 +5,12 @@
 //  Created by Gil Birman on 9/1/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapManager : RCTViewManager
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/1/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 
 #import "AIRGoogleMapManager.h"
 #import <React/RCTViewManager.h>
@@ -473,3 +475,5 @@ RCT_EXPORT_METHOD(setMapBoundaries:(nonnull NSNumber *)reactTag
     [googleMapView didTapPOIWithPlaceID:placeID name:name location:location];
 }
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.h
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/2/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTBridge.h>
 #import "AIRGMSMarker.h"
@@ -44,3 +46,5 @@
 - (void)didEndDraggingMarker:(AIRGMSMarker *)marker;
 - (void)didDragMarker:(AIRGMSMarker *)marker;
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/2/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapMarker.h"
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTImageLoader.h>
@@ -319,3 +321,5 @@ CGRect unionRect(CGRect a, CGRect b) {
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.h
@@ -5,8 +5,12 @@
 //  Created by Gil Birman on 9/2/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapMarkerManager : RCTViewManager
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -5,6 +5,8 @@
 //  Created by Gil Birman on 9/2/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapMarkerManager.h"
 #import "AIRGoogleMapMarker.h"
 #import <MapKit/MapKit.h>
@@ -69,3 +71,5 @@ RCT_EXPORT_METHOD(hideCallout:(nonnull NSNumber *)reactTag)
   }];
 }
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
@@ -4,6 +4,8 @@
 //  Created by Taro Matsuzawa on 5/3/17.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTBridge.h>
@@ -21,3 +23,5 @@
 @property (nonatomic, weak) RCTBridge *bridge;
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
@@ -3,6 +3,8 @@
 //  Created by Nick Italiano on 3/5/17.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapOverlay.h"
 
 #import <React/RCTEventDispatcher.h>
@@ -74,3 +76,5 @@
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.h
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTBridge.h>
 #import "AIRGMSPolygon.h"
@@ -26,3 +28,5 @@
 @property (nonatomic, assign) BOOL tappable;
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapPolygon.h"
 #import "AIRGMSPolygon.h"
 #import <GoogleMaps/GoogleMaps.h>
@@ -94,3 +96,5 @@
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.h
@@ -4,8 +4,12 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapPolygonManager : RCTViewManager
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
@@ -3,6 +3,8 @@
 //
 //  Created by Nick Italiano on 10/22/16.
 //
+
+#ifdef HAVE_GOOGLE_MAPS
 #import "AIRGoogleMapPolygonManager.h"
 
 #import <React/RCTBridge.h>
@@ -40,3 +42,5 @@ RCT_EXPORT_VIEW_PROPERTY(tappable, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.h
@@ -3,6 +3,8 @@
 //
 //  Created by Nick Italiano on 10/22/16.
 //
+
+#ifdef HAVE_GOOGLE_MAPS
 #import <UIKit/UIKit.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTBridge.h>
@@ -28,3 +30,5 @@
 @property (nonatomic, assign) BOOL tappable;
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.m
@@ -3,6 +3,8 @@
 //
 //  Created by Nick Italiano on 10/22/16.
 //
+
+#ifdef HAVE_GOOGLE_MAPS
 #import <UIKit/UIKit.h>
 #import "AIRGoogleMapPolyline.h"
 #import "AIRGMSPolyline.h"
@@ -109,3 +111,5 @@
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.h
@@ -4,8 +4,12 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapPolylineManager : RCTViewManager
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapPolylineManager.h"
 
 #import <React/RCTBridge.h>
@@ -41,3 +43,5 @@ RCT_EXPORT_VIEW_PROPERTY(tappable, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapURLTileManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapURLTileManager.m
@@ -3,6 +3,8 @@
 //  Created by Nick Italiano on 11/5/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapUrlTileManager.h"
 #import "AIRGoogleMapUrlTile.h"
 
@@ -26,3 +28,5 @@ RCT_EXPORT_VIEW_PROPERTY(maximumZ, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(minimumZ, NSInteger)
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTile.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTile.h
@@ -3,6 +3,8 @@
 //  Created by Nick Italiano on 11/5/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
 
@@ -15,3 +17,5 @@
 @property NSInteger *minimumZ;
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTile.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTile.m
@@ -3,6 +3,8 @@
 //  Created by Nick Italiano on 11/5/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "AIRGoogleMapUrlTile.h"
 
 @implementation AIRGoogleMapUrlTile
@@ -45,3 +47,5 @@
 }
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTileManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTileManager.h
@@ -3,8 +3,12 @@
 //  Created by Nick Italiano on 11/5/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <Foundation/Foundation.h>
 #import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapUrlTileManager : RCTViewManager
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
+++ b/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/23/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTConvert.h>
@@ -11,3 +13,5 @@
 @interface RCTConvert (GMSMapViewType)
 
 @end
+
+#endif

--- a/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
+++ b/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
@@ -4,6 +4,8 @@
 //  Created by Nick Italiano on 10/23/16.
 //
 
+#ifdef HAVE_GOOGLE_MAPS
+
 #import "RCTConvert+GMSMapViewType.h"
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTConvert.h>
@@ -20,3 +22,5 @@
     }
   ), kGMSTypeTerrain, intValue)
 @end
+
+#endif

--- a/lib/ios/AirMaps.xcodeproj/project.pbxproj
+++ b/lib/ios/AirMaps.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		628F81201FD16DF80058313A /* AIRMapLocalTile.m in Sources */ = {isa = PBXBuildFile; fileRef = 628F811F1FD16DF80058313A /* AIRMapLocalTile.m */; };
 		628F81231FD16EFA0058313A /* AIRMapLocalTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 628F81221FD16EFA0058313A /* AIRMapLocalTileManager.m */; };
 		62AEC4D41FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 62AEC4D31FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m */; };
+		8BC85FB02107CFEC0006CEA5 /* AIRGoogleMapOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC85FAF2107CFEC0006CEA5 /* AIRGoogleMapOverlay.m */; };
 		9B9498CA2017EFB800158761 /* AIRGoogleMapUrlTile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B9498A62017EFB400158761 /* AIRGoogleMapUrlTile.m */; };
 		9B9498CB2017EFB800158761 /* AIRGoogleMapURLTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B9498A72017EFB400158761 /* AIRGoogleMapURLTileManager.m */; };
 		9B9498CC2017EFB800158761 /* AIRGMSPolygon.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B9498A82017EFB400158761 /* AIRGMSPolygon.m */; };
@@ -109,6 +110,9 @@
 		628F81211FD16EAB0058313A /* AIRMapLocalTileManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AIRMapLocalTileManager.h; sourceTree = "<group>"; };
 		628F81221FD16EFA0058313A /* AIRMapLocalTileManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AIRMapLocalTileManager.m; sourceTree = "<group>"; };
 		62AEC4D31FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AIRMapLocalTileOverlay.m; path = AirMaps/AIRMapLocalTileOverlay.m; sourceTree = "<group>"; };
+		8BC85FAD2107C0BD0006CEA5 /* User.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = User.xcconfig; sourceTree = "<group>"; };
+		8BC85FAE2107CFD80006CEA5 /* AIRGoogleMapOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AIRGoogleMapOverlay.h; path = "../../../../../react-native-maps/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h"; sourceTree = "<group>"; };
+		8BC85FAF2107CFEC0006CEA5 /* AIRGoogleMapOverlay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AIRGoogleMapOverlay.m; path = "../../../../../react-native-maps/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m"; sourceTree = "<group>"; };
 		9B9498A42017EFB400158761 /* AIRGoogleMapCallout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AIRGoogleMapCallout.h; path = AirGoogleMaps/AIRGoogleMapCallout.h; sourceTree = "<group>"; };
 		9B9498A52017EFB400158761 /* AIRGoogleMapPolygonManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AIRGoogleMapPolygonManager.h; path = AirGoogleMaps/AIRGoogleMapPolygonManager.h; sourceTree = "<group>"; };
 		9B9498A62017EFB400158761 /* AIRGoogleMapUrlTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AIRGoogleMapUrlTile.m; path = AirGoogleMaps/AIRGoogleMapUrlTile.m; sourceTree = "<group>"; };
@@ -171,6 +175,7 @@
 				62AEC4D31FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m */,
 				11FA5C531C4A1296003AC2EE /* AirMaps */,
 				11FA5C521C4A1296003AC2EE /* Products */,
+				8BC85FAD2107C0BD0006CEA5 /* User.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -268,6 +273,8 @@
 				9B9498C92017EFB800158761 /* AIRGoogleMapPolygonManager.m */,
 				9B9498B82017EFB600158761 /* AIRGoogleMapPolyline.h */,
 				9B9498BB2017EFB600158761 /* AIRGoogleMapPolyline.m */,
+				8BC85FAE2107CFD80006CEA5 /* AIRGoogleMapOverlay.h */,
+				8BC85FAF2107CFEC0006CEA5 /* AIRGoogleMapOverlay.m */,
 				9B9498B62017EFB500158761 /* AIRGoogleMapPolylineManager.h */,
 				9B9498B12017EFB500158761 /* AIRGoogleMapPolylineManager.m */,
 				9B9498C82017EFB800158761 /* AIRGoogleMapUrlTile.h */,
@@ -365,6 +372,7 @@
 				1125B2DA1C4AD3DA007D0023 /* AIRMap.m in Sources */,
 				1125B2DF1C4AD3DA007D0023 /* AIRMapCoordinate.m in Sources */,
 				9B9498D62017EFB800158761 /* AIRGoogleMapCircleManager.m in Sources */,
+				8BC85FB02107CFEC0006CEA5 /* AIRGoogleMapOverlay.m in Sources */,
 				1125B2F21C4AD445007D0023 /* SMCalloutView.m in Sources */,
 				2163AA501FEAEDD100BBEC95 /* AIRMapPolylineRenderer.m in Sources */,
 				9B9498D02017EFB800158761 /* AIRGoogleMapPolylineManager.m in Sources */,
@@ -469,6 +477,7 @@
 		};
 		11FA5C5B1C4A1296003AC2EE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8BC85FAD2107C0BD0006CEA5 /* User.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
@@ -483,6 +492,7 @@
 		};
 		11FA5C5C1C4A1296003AC2EE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8BC85FAD2107C0BD0006CEA5 /* User.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",

--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/airbnb/react-native-maps.git" }
   s.source_files  = "lib/ios/AirGoogleMaps/**/*.{h,m}"
-  s.compiler_flags = '-fno-modules'
+  s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-DHAVE_GOOGLE_MAPS_UTILS=1', '-fno-modules'
 
   s.dependency 'React'
   s.dependency 'GoogleMaps', '2.5.0'


### PR DESCRIPTION
Adds missing `#ifdef HAVE_GOOGLE_MAPS` checks to `AIRGoogleMapOverlay.h` and `AIRGoogleMapOverlay.m`.